### PR TITLE
doc: add main guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,36 @@
-# validator-community
-This repository is community-owned, providing future AtomOne community validators with a platform to share information, coordinate efforts, and submit pull requests related to the potential future of the AtomOne project.
+# atomone-validator-community
 
-Validators can utilize this repository as needed. If you’re a validator and would like to contribute to on-going efforts, please open up an issue to be added to the repository. 
+This repository is community-owned, providing future AtomOne community
+validators with a platform to share information, coordinate efforts, and submit
+pull requests related to the potential future of the AtomOne project.
 
-For more immediate communication, you are also welcome to use [the validator channel on Discord](https://discord.com/channels/1050058681414340701/1052259303924445204).
+Validators can utilize this repository as needed. If you’re a validator and
+would like to contribute to on-going efforts, please open up an issue to be
+added to the repository. 
+
+For more immediate communication, you are also welcome to use [the validator
+channel on Discord](https://discord.com/channels/1050058681414340701/1052259303924445204).
+
+## Guide
+
+This guide provides practical information for AtomOne validators: 
+
+### Release
+
+Download the v1.0.0 atomoned binary from https://github.com/atomone-hub/atomone/releases/tag/v1.0.0
+
+### Proposed base Genesis file
+
+You can download the base genesis file (without the gentxs) at https://atomone.fra1.digitaloceanspaces.com/genesis.json
+
+Other recommendations and useful informations can be found [here](./atomone-1/README.md).
+
+### Other Recommended Steps
+
+Here is a list of recommended tasks that could be beneficial to have as
+completed according to industry best practices:
+- host an explorer like a ping.pub instance and configure it properly
+- register the `atone` address prefix to github.com/satoshilabs/slips ([example](https://github.com/satoshilabs/slips/pull/1687))
+- submit the chain info to keplr-chain-registry ([example](https://github.com/chainapsis/keplr-chain-registry/pull/466))
+- submit the chain info to cosmoschain-registry ([example](https://github.com/cosmos/chain-registry/pull/4000))
+


### PR DESCRIPTION
Dear Validators, 

Following [GovGen Proposal #5](https://commonwealth.im/govgen/discussion/24802-cosmos-softwares-versioning), which outlines the software versioning for the proposed AtomOne chain, please find below the release for the AtomOne genesis software. We hope that this guide provides the necessary information for you to coordinate amongst yourselves for the project’s next steps, including the potential decentralized launch of the AtomOne chain.

If you have any technical questions that you believe we could help you with, please don’t hesitate to let us know.