### PR TITLE
Add all verified validator entries to validator-info.md (77 rows from 71 PRs)

### DIFF
--- a/validator-info.md
+++ b/validator-info.md
@@ -8,58 +8,83 @@ In order to verify the team members of your validator, please send a 0.01 ATONE 
 |---|---|---|---|---|---|---|---|
 | Validator Name  | Validator Website | Validator Twitter Page | Region | GitHub Handles | E-mails | Discord Handles | Tx Hash |
 | Stella  |  https://twitter.com/StellaNodex | https://twitter.com/StellaNodex  | Malta  | https://github.com/StellaNodeX/  |  stellanodex@gmail.com | stellanode  | 437CF6F40AB63B2B07765A8DC22821E51BCBABBD34CAA72B2A14413C6E182C26  |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
-|   |   |   |   |   |   |   |   |
+| CroutonDigital | https://crouton.digital | https://x.com/CroutonDigital | Latvia | https://github.com/CroutonDigital | official@crouton.digital | romanv1812, crouton.digital, ak32821 | https://www.mintscan.io/atomone/tx/923002A0B93CFAD5F822841B794557D906F126BB7B4631EA80D0D12BA0823736?height=2017570 |
+| equinoxDAO | https://www.equinoxdao.xyz | https://x.com/EquinoxDAO | U.K. | https://github.com/Equinox-DAO | wangzhaozhu1@gmail.com | samwang_ | E8487EB3F077315C09B16DC3B64181F2E84993B8EB3986BED39F1163A4865BAF |
+| AlxVoy ⚡ ANODE.TEAM | https://anode.team | https://x.com/Voynitskiy | Indonesia | https://github.com/Voynitskiy | alxvoy@anode.team | alxvoy | 8CAC1904494187CD59ADF97C91A2971E7C24C13304FB1205B37CD9EF44068471 |
+| cunum | https://cosmos.cunum.com | [@CunumStaking](https://x.com/CunumStaking) | Germany | cunum | staking@cunum.com | cunum_04458 | 9F6CC413787149F8DD6789CDB45ED9B4558A33A66ECE349FDD4FDE4197993C42 |
+| Nodeist | [nodeist.net](https://nodeist.net) | [@nodeistt](https://x.com/Nodeistt) | Turkey | [nodeiistt](https://github.com/nodeiistt) | hello@nodeist.net | nodeist | [Link](https://www.mintscan.io/atomone/tx/D8CE39436FEE367D148872F777B5DB1E451A43733C2707FC209186D07C2A0A2D?height=281486) |
+| 0base.vc | https://0base.vc | https://x.com/0baseVC | South Korea | https://github.com/0base-vc | 0@0base.vc | jjangg96 | 8714DD176A227A9F749DF905668E6936CF7CA0FA696B245990823EC071640898 |
+| PathrockNetwork | https://pathrocknetwork.org/ | https://x.com/pathrock2 | Europe, Estonia | https://github.com/paddyson79 | pathrock@protonmail.com | paddyson | AC5CEA3B6810D16DF3DD8323FBE1EFFF557FBD60D9F730E968F7DA268BEEBB6B |
+| Inter Blockchain Services | https://ibs.team | https://x.com/IBSvalidator | France | https://github.com/Inter-Blockchain-Service | contact@ibs.team | remiinterblockchainservices,jayinterblockchainservices | 1F8722DC4DC7EBF1EB279F8A4053CA5AD00E5A35C6135E8BC795070A3860CD27 |
+| PRO Delegators | https://pro-delegators.com | - | Switzerland | Nuxian-Labs | contact@nuxian.ch | @ciskos_nuxianlabs / @rafinoo | 806AD7A1BED4067F9ADA7312CAF0EDA632AE793CD290BBCB7A2074475F0477F5 |
+| Zuka | zukahub.com | [Zuka](https://x.com/ok7i3) | Russia | [zukaman](https://github.com/zukaman) | sw48264@gmail.com | zuka_116 | [Link](https://www.mintscan.io/atomone/tx/09564B8B3FCFBFF3A84430F2E4BA7289D29B540DB12B9FF2D9BCB89DCFD84FAB?height=291010) |
+| Noderunners | http://noderunners.biz | https://x.com/noderunners | Netherlands | rewseRE | info@noderunners.biz | rewse | 190AAE993EAE3BAFD7E8A8BDF8ACA0EC8A519A074AD8225BFC0942644AA197B5 |
+| plantree | https://plantree.org | - | Belarus/Eastern Europe | https://github.com/plantree-validator | contact@plantree.org | upnp | https://www.mintscan.io/atomone/tx/8E132EF5E52652B27001D13C88EF6534A0CE51231BA1B70C2F320C751FF60815 |
+| DragonStake | [DragonStake](https://dragonstake.io) | [@DragonStake](https://x.com/dragonstake) | Spain | dragonstake, derfredy | info@dragonstake | gufete_dragonstake, derfredy, jesusperezcryptoplaza | 47757F93C738231639D778C19F26E80E44E7201EABC05774FA831ECB8665D010 |
+| Simply Staking | https://simplystaking.com/ | https://x.com/SimplyStaking | Malta | Bonavia55 DanielMagro97 frangrech | staking@simplystaking.com | aaronsimply frangre danielsimplystaking | 39E534382BAE3899927CD73519A7117D58483F3C5C79F80EB85B3FA17952E857 |
+| Foxinodes | https://foxinodes.net | https://x.com/foxinodes | Europe | @FoxinouFR | validator@foxinodes.net | @foxinoufr | F1D05E0697FE69101846083E143A8A50BBF9C6DDF2D4677FDAE9FBB57C09A56C |
+| 🔥 BIERFORGE ⚒ 🔥 REStake | https://bierforge.com | https://twitter.com/@bierforge | South Africa | BierForge | bierforge@outlook.com | BIERFORGE(honcho_404) | FA2AA275F2CCCF0B4A27BAC7FBA09D9B0337A7BC775B22ACF700C742BA6CF21F |
+| tRDM I Nodera | https://nodera.tech | https://x.com/tRDM_2598 | Moldova | https://github.com/terdim28/ | terdim28@gmail.com | trdm | 34FB57C338ADA39E752D0A84942C40A84A1E148F4756533A3A7BED0EC782904E |
+| LuckyStar | https://www.luckystar.asia | https://x.com/LuckyStar_Asia | Germany | https://github.com/LuckyStarAsia | aluckystarasia@gmail.com | luckystar.asia | BFCBFC5E629932646D27C17CEDCE3E6AD8EE1E805EE95023A79FCE385B0A66C9 |
+| Silk Nodes | https://silknodes.io/ | https://twitter.com/silk_nodes | Ireland & USA | https://github.com/Silk-Nodes | info@silknodes.io | Bosco Silk Nodes & .Mud Silk Nodes" | 7BAA2AFAE30279C61A751142308C0EF0E8D9A873EE04019F34CA4C97979CE58B |
+| POSTHUMAN | https://posthuman.digital/ | https://x.com/POSTHUMAN_DVS | Planet Earth | https://github.com/Validator-POSTHUMAN/ | validator@posthuman.digital | antropocosmist | A583C71823C6D8EB613517A7545CB62751B636CDF791ADBD946CC5BBEFB38F97 |
+|  |  |  |  |  |  | albertopentstaking |  |
+|  |  |  |  |  |  | web34ever |  |
+|  |  |  |  |  |  | cyberg |  |
+|  |  |  |  |  |  | write2sd |  |
+|  |  |  |  |  |  | posthuman_validator |  |
+| NyanCat | https://x.com/o___victor | https://x.com/o___victor | Ukraine | https://github.com/VictorOsipchuk | onemoment1760@gmail.com | nyancat007 | D0BB9A6894FFDEF32CB6FDC60FEC9535C19C15AAF3CF992B4A1D1E5206D7ECD1 |
+| GATA HUB | https://gatahub.zone | https://twitter.com/GataHubZone https://twitter.com/GataDaoZone | Germany UAE | JoveCosmos ABCharlieEth | jovecosmos@gmail.com gatadaozone@gmail.com | jovegatadao wassieofgata | E2FBBA2712037883BFCCCCA39D858E6C6F4D6764B433D4159816649AAC1B0CB8 |
+| Regenerator | https://regenerator.online | @Regenerator_ | UK | p3t3hill | contact@regenerator.online | pete_regenerator | 765498F2B00A5DDB34BAEB9D68D8130FC8B5F89905129F7AC2A5FC8B05A14295 |
+| Nodes Hub 🛡️ 100% Slash Protected 🛡️ | https://nodeshub.online | https://x.com/Nodes_Hub | India, Dubai, Singapore | https://github.com/NodesHub | contact@nodeshub.online | nodeshub | E8BD20CD829849348F5063AD68C7A7B94873E58C20AF56DF52AA58251BDC6D36 |
+| UTSA | https://utsa.gitbook.io/services | https://x.com/lesnik13utsa | Armenia | lesnikutsa | lesnik13utsa@yandex.ru | lesnik_utsa | 88C719C330ACB5B639C8A63B4A105DD86C2969C5F000187E41A2946DC636AA0F |
+| SyaNodes | https://docs.syanodes.my.id | https://x.com/syanodes | Indonesia | https://github.com/SyaNodes | syanodess@gmail.com | .syanodes | 95D69DCB858A2AC1AC8A8078B447EECCCE2989510887ECA4A244E505E7DC868E |
+| ruangnode | https://ruangnode.com | https://x.com/ruangnode | Indonesia | https://github.com/ruangnode | contact@ruangnode.com | ruangnode.com | B42D2C80F3E0B5BDA28AF74056AB52385D3C377CA3F87BE77BC1D2420C63171F |
+| Ubik Capital | https://ubik.capital/ | https://x.com/ubikcapital | Romania | ubikcapital | contact@ubik.capital | ubikcapital | CFFC7D9CF748617AD7A60F3A679955723F175C1285C006C5BD502A2740B3338E |
+| Nurturra | https://nurturra.zone |  | Canada | https://github.com/Nurturra | nurturagrowth@gmail.com | nurturra | 0C31873A9A4FAA449534EA427392984C0F6315D9E44BA1FE83E544E19CD8F801 |
+| Nodedog | https://nodedog.io | N/A | Germany | https://github.com/nodedogg | nodedog1@gmail.com | iron32850 | 33E2221AC3847F8D1A27E8203C5C5FF5C70E2B191FD8677E773DCE3F32F7949F |
+| Chainroot | chainroot.io | @chainroot_io | Sweden | @chainroot | contact@chainroot.io / mehrdad@chainroot.io | @chainroot | A7BDE6A0D1A03D353F4A36E13B2844C7188920B4A189C817F39290CFC81FF9C9 |
+| Shazoe | https://services.shazoe.xyz | https://x.com/_Shazoe | Indonesia | https://github.com/ketcebong | shazoenodes@gmail.com | _shazoe | 0324A34E31BC289B3B7665A0CE5269E33D846B804360D709A3E203B40268B295 |
+| KonsorTech | https://konsortech.xyz | https://x.com/Konsor_Tech | Indonesia | https://github.com/konsortech | validator@konsortech.xyz | konsortech | 2D33200507542A80D6E3D64E85E7C26EF452E741D299931FD7BB016DA8B4DB64 |
+| PrimeStake | https://primestake.top | N/A | Iceland | https://github.com/PrimeStakeTop | pprimestake@gmail.com | primestake.top | F753934D9C74B0BC6C5D799978D39B4094EBBA0D3D141BF4E032E239A688D1CE |
+| SIPALING-TESTNET | https://node.sipalingtestnet.com/ | https://x.com/sptnode | Indonesia | https://github.com/sipalingtestnet | sptnode@gmail.com | sptnode | A3836FFF0F5C5F313C8883D788F7D88299F516E446A788EC7DD74E6BC2F7E7E6 |
+| ITRocket | https://itrocket.net | https://x.com/itrocket_team | Armenia | itrocket-team | ops@itrocket.net | itrocket | A336AAF04FEF3D6C00086C641DCB6160ACEEE5AFCCDAFF2B3A511F0369B2539F |
+| StakeUp | https://stakeup.tech | https://x.com/stakeup_tech | Ukraine | https://github.com/landerosua | contact@stakeup.tech | landeros | E913ED3A453DDE22A39D9798000B85CE1F5E895B4AF1C115C0E72B0CB297770B |
+| Apollo | - | https://x.com/petr_zelivsky | Czech Republic | https://github.com/Zelivsky | apollo.validator@gmail.com | zelivsky | C6FF3A821152578E44CAEE5D5F1ECE0949C0932B37884B7B642D5D4C1DB331AC |
+| Tecnodes | www.tecnodes.network | https://x.com/TecnodesNetwork | Estonia | tecnodes-network | tecnodes.network@gmail.com | tecnodes | https://explorer.tecnodes.network/atomone/tx/988853E9AC65FAFB24EEDA058E6C45E431CD070ABF3F001CC98460A520371537 |
+| HEXXAGON | https://www.hexxagon.io | https://x.com/hexxagon_io | Canada | hexxagon-io | support@hexxagon.io | echel0n_hx | https://www.mintscan.io/atomone/tx/C77A90AA1552C3E94A29445EF212517CDAF7925F58AFD9AC50C22AF1625A390F |
+| Shire | https://x.com/shirestaking | https://x.com/shirestaking | UAE | https://github.com/Bilboshire | shirestaking@gmail.com | mazicosmos | 0508435D849AF264618C9B6393915326803778B830172591ABF44459808A6FA1 |
+| ChainTools | https://chaintools.tech | https://x.com/ChaintoolsT | Poland | qf3l3k, ChainTools-Tech | contact@chaintools.tech | qf3l3k_chaintools | 049FCD38B8AC27E59A5AE33191AEB591CE7D53F5AC59C415C0EC45A7AF77876F |
+| Kynraze | https://kynraze.com | https://x.com/Kynraze | Indonesia | kynraze | kyn@kynraze.com | kynraze | 072E8CE2A42A129F95B3E40CCC5552E4EBD919EA6CD6514F0346082BB404A98A |
+| Akat \| Suki | http://www.akatsukinodes.com/ | https://x.com/AkatsukiNodes | Singapore | https://github.com/akatsuki-nodes | akatsuki.nodes@gmail.com | akatsukival | EC8592084BD82F2699A5C08A5C3F6BCEEC12EF93E7F045AA684A6604A7866ABC |
+| owlstake | https://owlstake.com | https://x.com/owlstake | Vietnam | https://github.com/owlstake | work@owlstake.com | owlstake | 21B74BA17A5A3BB72F8349610EEC77F05B3082A936FA0FB04F5DA5EFE524020E |
+| BonyNode💚 | https://bonynode.online | https://x.com/bonynode | Ukraine | https://github.com/cryptobits3 | cryptoobony@gmail.com | bonynode | 0C361452569D1F50578D5CE77C155E74ED870E5583627540CFB7372C6B94338B |
+| Revonode | https://revonode.xyz | https://x.com/revonode_xyz | Indonesia | @revonode | hi@revonode.xyz | revo_o | 354BBAAD106466114E14D51EDAECCC6DCF1A41EBFE46F3D0C9F2E93A9183C050 |
+| CosmicNode | [cosmicnode.zone](https://cosmicnode.zone/) | https://x.com/_CosmicNode | EU | Cosmic-Node | support@cosmicnode.zone | gilgalidd | 419F0B362ED2268F5D76FC361194BBF33017D2EDF7F6AB0E5F960090B0AA7E60 |
+| CoinHunters | https://nodes.coinhunterstr.com/ | https://x.com/CoinHuntersTR | Turkiye | https://github.com/CoinHuntersTR | coinhunterstr@gmail.com | 0xmtnslk | 9C40937B0A2B5B4E4E85F69803FC2470D9D8020975E57FB2269D4E992E519CCE |
+| KalpaTech | https://kalpatech.co | https://x.com/@kalpa_tech | Romania | kalpatech-team | info@kalpatech.co | goldelkalpatech | B9FA2A7F3DD14DDCA582A86B111AE2C2DB3F0737DD78610141A6F1B365A3D88C |
+| NexuSecurus | nexusecurus.com | @nexusecurus | Portugal | nexusecurus | atomone@nexusecurus.com | _nexusecurus_ | 7C50D046C7D7884014480D681ED02ACD84D1E5E817F885EF97BEFF882886D932 |
+|  |  |  |  | prenats | support@nexusecurus.com | prenats |  |
+|  |  |  |  |  |  | dvr.2 |  |
+|  |  |  |  |  |  | maraja3024 |  |
+| StakerHouse | https://stakerhouse.com | https://x.com/stakerhouse | Georgia | postpuber | contact@stakerhouse.com | stakerhouse | 69061B8776AAAC2C7DD175EDF65B4D9D582453A6D857FDB7265E392F9559B2C4 |
+| Inotel | https://inotel.ro |  | Romania | mabalaru |  | mabalaru | ABE60C1A965F7CF5A87D0535B76BF113BC1FE450D5BE51AC4BCCD325A1B4AB2D |
+| Crypto Plant | https://cryptoplant.notion.site | https://x.com/plant_crypto | South Korea | TedChun3 | plant.crypto@gmail.com | tedc. | 49F92F7BF06F46488A4B32D5A1901B60232457C84105770B832DD1A3E093D25B |
+| Onbloc Node | https://onbloc.xyz | https://x.com/onblocxyz | South Korea | seokheejang, js712 | shjang@onbloc.xyz, js712@onbloc.xyz | dao6320, jsjs4390 | BBE235194E4F0052FB26BA3FC97DD78E7B76639C7E0C122A1DD867ACBBD0F995 |
+| OWALLET | https://owallet.io | https://x.com/owallet_io | Singapore | phutxorai | phu.tx@orai.io | tranphu.dev | 8CA99B9A5992E791E694FA18FB7A0F210B61C27894EA31D2CF97C77E6C6A5DBB |
+| BZE Community | getbze.com | https://x.com/BZEdgeCoin | Romania | https://github.com/faneaatiku | alphateam@getbze.com, faneatiku@yahoo.com | faneatiku | 0254A2F506D5A340613535CD904EF3032074D8801E6BA1F5DA8006AFC9D1C626 |
+| Tanjira | Tanjira.com | https://twitter.com/Tanjirapr | North America, Canada | jtoba66, m3rryqold | tanjiravalidator@gmail.com | tanjira_58334 , jauziv | A9149F9277A018369F85896AB295DAB17C50E3D9E8DDE39643518A0C9CB3CAA1 |
+| ECO Stake 🌱 \| REStake.app | https://ecostake.com | https://x.com/eco_stake | Germany | eco-stake | support@ecostake.com | ecostake | 08DC4DA4E336F8F23959F1598ED5293E6DFBD72529638EF0B1E50106F83306DB |
+| TaxiStake | https://taxistake.com/ | https://x.com/TaxiStake | USA | https://github.com/TaxiStake-org/ | validators@taxistake.com | scoh.taxistake, grithaxe | 513B7D2EC088B5DD1168359F3E9C12726DAB9D0AD357DD329C1EB87DA17094F3 |
+| Simply Staking | https://simplystaking.com/ | https://x.com/SimplyStaking | Malta | lvc086 frangrech DanielMagro97 | staking@simplystaking.com | lukevcsimplystaking frangre danielsimplystaking | 2AFB09011033C0637CB636DD9217F8A267AC48D10999EC51588B498288395564 |
+| NosNode🔮 | https://nosnode.com | https://x.com/Nostradamus411 | Midwest USA | @Nostradamus411 | nos@nosnode.com | nostradamus.nosnode | 38E37CDDFAD0C9F09A5EC557B8BE109768B980AAED0928EF8EA58FA4B3F2AC0D |
+| dnsarz | https://dnsarz.xyz | https://x.com/aidilfahmii | Indonesia | http://github.com/aidilfahmi | dnsarz@gmail.com | dnsarz | https://www.mintscan.io/atomone/tx/87819DE3A24C36D3FDB2B9C47D73F5E12EC0DBDA5DA734D55CF8FFA800EB410A |
+| p10node | https://p10node.com/ | https://x.com/p10node | Vietnam | p10node | security@p10node.com | pierreneter | 58C133678976FAF8ED69B0DD61D4B909483EDDEAB9C683F42156A217FED0CFE4 |
+| openbitlab | https://openbitlab.com/ | https://x.com/Openbitlab_node | Italy | openbitlab2 | openbitlab@gmail.com | openbitlab lu191 dakk_k | CDCEF3C111E5F72E8DC987632B8C27CCBE4B984CBA741CD910A695C6B3419C0B |
+| HusoNode | https://husonode.xyz/ | https://x.com/husonode | Finland | aksamlan | contact@husonode.xyz | aksamlan | https://www.mintscan.io/atomone/tx/01B848DFCD11859C383DA5470382F5A7579776169F4C0335D91E29C6DDA5BF72?height=5942318 |
+| Onbloc Node | https://onbloc.xyz | https://x.com/onblocxyz | South Korea | js712, hwiwon.sean | js712@onbloc.xyz, hwiwon.sean@onbloc.xyz | jsjs4390, seanj777_69654 | DED8998359F4AB5D6690003A72CC0F7A1D14E74B98A7CE411D53097E72631747 |
+| Onbloc Node | https://onbloc.xyz | https://x.com/onblocxyz | South Korea | jinoosss | jwchoi@onbloc.xyz | jinoosss | B4643B670660FFF9822255FEB0F393E1A602DBEDD8B8234E89179465A30345B0 |
+| Onbloc Node | https://onbloc.xyz | https://x.com/onblocxyz | South Korea | jinoosss,wookja-0 | jwchoi@onbloc.xyz,wj.jung@onbloc.xyz | jinoosss,wj5445 | EAFC99F73D8E4A2A0003F9BA6BF9BBA05EBC107F83DF2B5B91A2757024391C2E |
 |   |   |   |   |   |   |   |   |
 |   |   |   |   |   |   |   |   |
 |   |   |   |   |   |   |   |   |


### PR DESCRIPTION
Lands the table rows from every PR whose submission passes all three checks the form asks for, as audited in #168:

1. the TX hash exists on `atomone-1`;
2. the memo lists the Discord handles given in the *Discord handles* column;
3. the TX was signed by the **validator's own account** — the signing address, re-encoded as `atonevaloper…`, is that validator's operator address.

**77 rows from 71 PRs.**

### Why one PR instead of merging them individually

Every one of those PRs rewrote the *same* placeholder row, and `main` already has Stella's row there from #110. **64 of the 66 open ones report `CONFLICTING`**, and merging any single one would leave the other 63 conflicting — the order doesn't help. Landing the rows together avoids asking 69 contributors to rebase.

### Changes made to the submitted rows

Rows are copied verbatim from each PR, except:

- **Escaped an unescaped `|`** in two validator names so the row keeps its 8 columns: `Akat \| Suki` (#120) and `ECO Stake 🌱 \| REStake.app` (#150). Rendered as submitted, these split the row into 9 cells and shifted every column after the name.
- **Dropped the duplicate NexuSecurus row** — #133 and #134 are the same submission with the same TX; kept one.
- **Took only the table row from #93 (Ubik Capital) and #156 (openbitlab).** Both PRs *rename* `validator-info.md` to their own filename, which would delete the shared file. Their entries are valid, so the rows are included and the rename is not.
- **Took only the table row from #126 (BonyNode).** That PR adds a separate `BonyNode validator-info.md` rather than editing the shared file.
- Kept 25 placeholder rows at the end for future submissions.

### Needs a maintainer decision

Two validators submitted more than once, each time with a different TX proving a different set of handles. All the submissions are individually valid, so I kept every row rather than silently dropping data — but you may want one row per validator:

- **Simply Staking** — 2 rows (#65: `aaronsimply frangre danielsimplystaking` · #152: `lukevcsimplystaking frangre danielsimplystaking`)
- **Onbloc Node** — 4 rows (#141: `dao6320, jsjs4390` · #162: `jsjs4390, seanj777_69654` · #166: `jinoosss` · #167: `jinoosss, wj5445`)

### Included PRs

Open: #20 #34 #43 #44 #45 #46 #50 #51 #56 #57 #59 #62 #63 #65 #66 #70 #73 #76 #80 #81 #82 #84 #88 #90 #92 #93 #94 #97 #98 #99 #100 #101 #102 #104 #106 #107 #114 #116 #117 #118 #119 #120 #124 #126 #127 #129 #131 #134 #136 #137 #140 #141 #142 #146 #147 #150 #151 #152 #153 #154 #155 #156 #159 #162 #166 #167

Closed but valid, rows included here: #77 #78 #128 #133 — no need to reopen them.

Already merged, row untouched: #110.

### After this lands

The individual PRs can be closed with a comment pointing here. Note **#34 (equinoxDAO) also adds `atomone-1/gentx/EquinoxDAO.json`**, which is *not* included here — genesis is long past, so it is historical, but close it knowingly.

Not included: the 48 invalid and 5 partial submissions in #168. Those need the contributor to fix something (re-send from the validator account, put the handles in the memo, or supply a TX that exists).